### PR TITLE
change version for spring-security-oauth2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     	<dependency>
         	<groupId>org.springframework.security.oauth</groupId>
         	<artifactId>spring-security-oauth2</artifactId>
-        	<version>2.0.7.RELEASE</version>
+        	<version>[2.0.15,)</version>
     	</dependency>
     	<dependency>
 			<groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Version update for spring-security-oauth2 according to GitHub Alert:

**Remediation**
Upgrade org.springframework.security.oauth:spring-security-oauth2 to version 2.0.15 or later. For example:

```
<dependency>
  <groupId>org.springframework.security.oauth</groupId>
  <artifactId>spring-security-oauth2</artifactId>
  <version>[2.0.15,)</version>
</dependency>

```

**CVE-2016-4977**
Vulnerable versions: < 2.0.10
Patched version: 2.0.10
When processing authorization requests using the whitelabel views in Spring Security OAuth 2.0.0 to 2.0.9 and 1.0.0 to 1.0.5, the response_type parameter value was executed as Spring SpEL which enabled a malicious user to trigger remote code execution via the crafting of the value for response_type.

**CVE-2018-1260**
Vulnerable versions: >= 2.0.0, < 2.0.15
Patched version: 2.0.15
Spring Security OAuth, versions 2.3 prior to 2.3.3, 2.2 prior to 2.2.2, 2.1 prior to 2.1.2, 2.0 prior to 2.0.15 and older unsupported versions contains a remote code execution vulnerability. A malicious user or attacker can craft an authorization request to the authorization endpoint that can lead to remote code execution when the resource owner is forwarded to the approval endpoint.